### PR TITLE
Refactor OrderContentsDecorator.add_to_line_item and bump version

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -37,5 +37,23 @@ module Spree
     def cost_money
       Spree::Money.new(cost_price, currency: currency)
     end
+
+    def add_customizations(product_customizations_values)
+      self.product_customizations = product_customizations_values
+      product_customizations_values.each { |product_customization| product_customization.line_item = self }
+      product_customizations_values.map(&:save) # it is now safe to save the customizations we built
+      customizations_offset_price = product_customizations_values.map {|product_customization| product_customization.price(variant)}.compact.sum
+      return customizations_offset_price
+    end
+
+    def add_ad_hoc_option_values(ad_hoc_option_value_ids)
+      product_option_values = ad_hoc_option_value_ids.map do |cid|
+        Spree::AdHocOptionValue.find(cid) if cid.present?
+      end.compact
+      self.ad_hoc_option_values = product_option_values
+      ad_hoc_options_offset_price = product_option_values.map(&:price_modifier).compact.sum
+      return ad_hoc_options_offset_price
+    end
+
   end
 end

--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -14,11 +14,12 @@ Spree::OrderContents.class_eval do
     #### separate options to standard, product_customizations, and add_hoc_option_values
     product_customizations_values = options[:product_customizations]
     ad_hoc_option_value_ids = options[:ad_hoc_option_values]
-    standard_options = options.except(:product_customizations, :ad_hoc_option_values)
+    standard_options = options.except(:product_customizations, :ad_hoc_option_values).to_h
     ######
 
     line_item.quantity += quantity.to_i
     line_item.options = ActionController::Parameters.new(standard_options).permit(Spree::PermittedAttributes.line_item_attributes).to_h
+    
 
     ####### This line is added to make solidus_flexi_variants save customizations
     if product_customizations_values != nil || ad_hoc_option_value_ids != nil

--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -14,12 +14,16 @@ Spree::OrderContents.class_eval do
     #### separate options to standard, product_customizations, and add_hoc_option_values
     product_customizations_values = options[:product_customizations]
     ad_hoc_option_value_ids = options[:ad_hoc_option_values]
-    standard_options = options.except(:product_customizations, :ad_hoc_option_values).to_h
+    standard_options = options.except(:product_customizations, :ad_hoc_option_values)
     ######
 
     line_item.quantity += quantity.to_i
-    line_item.options = ActionController::Parameters.new(standard_options).permit(Spree::PermittedAttributes.line_item_attributes).to_h
-    
+
+    if standard_options.class == ActionController::Parameters
+      line_item.options = standard_options.permit(Spree::PermittedAttributes.line_item_attributes).to_h
+    else
+      line_item.options = ActionController::Parameters.new(standard_options).permit(Spree::PermittedAttributes.line_item_attributes).to_h
+    end
 
     ####### This line is added to make solidus_flexi_variants save customizations
     if product_customizations_values != nil || ad_hoc_option_value_ids != nil

--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -1,9 +1,9 @@
 Spree::OrderContents.class_eval do
 
   private
-  #this whole thing needs a refactor!
 
   def add_to_line_item(variant, quantity, options = {})
+    ### overrides existing Spree::OrderContents private method
     line_item = grab_line_item_by_variant(variant, false, options)
 
     line_item ||= order.line_items.new(
@@ -11,27 +11,20 @@ Spree::OrderContents.class_eval do
       variant: variant,
     )
 
+    #### separate options to standard, product_customizations, and add_hoc_option_values
+    product_customizations_values = options[:product_customizations]
+    ad_hoc_option_value_ids = options[:ad_hoc_option_values]
+    standard_options = options.except(:product_customizations, :ad_hoc_option_values)
+    ######
+
     line_item.quantity += quantity.to_i
-    line_item.options = ActionController::Parameters.new(options).permit(Spree::PermittedAttributes.line_item_attributes).to_h
+    line_item.options = ActionController::Parameters.new(standard_options).permit(Spree::PermittedAttributes.line_item_attributes).to_h
 
-    unless options.empty?
-      product_customizations_values = options[:product_customizations] || []
-      line_item.product_customizations = product_customizations_values
-      product_customizations_values.each { |product_customization| product_customization.line_item = line_item }
-      product_customizations_values.map(&:save) # it is now safe to save the customizations we built
-
-      # find, and add the configurations, if any.  these have not been fetched from the db yet.              line_items.first.variant_id
-      # we postponed it (performance reasons) until we actually know we needed them
-      ad_hoc_option_value_ids = ( options[:ad_hoc_option_values].present? ? options[:ad_hoc_option_values] : [] )
-      product_option_values = ad_hoc_option_value_ids.map do |cid|
-        Spree::AdHocOptionValue.find(cid) if cid.present?
-      end.compact
-      line_item.ad_hoc_option_values = product_option_values
-
-      offset_price = product_option_values.map(&:price_modifier).compact.sum + product_customizations_values.map {|product_customization| product_customization.price(variant)}.compact.sum
-
-      line_item.price = variant.price_in(order.currency).amount + offset_price
+    ####### This line is added to make solidus_flexi_variants save customizations
+    if product_customizations_values != nil || ad_hoc_option_value_ids != nil
+      line_item = flexi_variants(variant, line_item, product_customizations_values, ad_hoc_option_value_ids)
     end
+    ######
 
     if Spree.solidus_version < '2.5' && line_item.new_record?
       create_order_stock_locations(line_item, options[:stock_location_quantities])
@@ -40,6 +33,27 @@ Spree::OrderContents.class_eval do
     line_item.target_shipment = options[:shipment]
     line_item.save!
     line_item
+  end
+
+  def flexi_variants(variant, line_item, product_customizations_values, ad_hoc_option_value_ids)
+      product_customizations_values ||= []
+      ad_hoc_option_value_ids ||= []
+      customizations_offset_price = 0
+      ad_hoc_options_offset_price = 0
+
+      if product_customizations_values.count > 0
+        customizations_offset_price = line_item.add_customizations(product_customizations_values)
+      end
+
+      # find, and add the configurations, if any.  these have not been fetched from the db yet.              line_items.first.variant_id
+      # we postponed it (performance reasons) until we actually know we needed them
+      if ad_hoc_option_value_ids.count > 0
+        ad_hoc_options_offset_price = line_item.add_ad_hoc_option_values(ad_hoc_option_value_ids)
+      end
+
+      line_item.price = variant.price_in(order.currency).amount + customizations_offset_price + ad_hoc_options_offset_price
+
+      return line_item
   end
 
   # Bringing in since it was taken out of version 2.5

--- a/solidus_flexi_variants.gemspec
+++ b/solidus_flexi_variants.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'solidus_flexi_variants'
-  s.version     = '1.0.0'
+  s.version     = '1.0.1'
   s.summary     = 'This is a solidus extension that solves two use cases related to variants.'
   s.description = 'Solidus extension to create product variants as-needed'
   s.required_ruby_version = '>= 2.1'


### PR DESCRIPTION
Changes to OrderContentsDecorator.add_to_line_item

- Separated incoming options hash into standard spree options, product_customizations, and ad_hoc-option_ids

- set line_item.options using standard spree options

- separated some logic into new flexi_variants method

- flexi_variants method calls new line_item instance methods to assign options and get price adjustments