### PR TITLE
Add tests for customizations on frontend. Add optional scope to updat…

### DIFF
--- a/app/helpers/spree/products_helper_decorator.rb
+++ b/app/helpers/spree/products_helper_decorator.rb
@@ -13,6 +13,20 @@ module Spree
       h
     end
 
+    def render_partial_for_customization_type(product_customization_type, product_calc_name)
+      lookup = ActionView::LookupContext.new(ActionController::Base.view_paths, {formats: [:html]})
+      param_prefix = "product_customizations[#{product_customization_type.id}]"
+      partial_name = "spree/products/customizations/customization_type/#{product_customization_type.name}"
+      partial_name2 =  "spree/products/customizations/calculator_type/#{product_calc_name}"
+      if lookup.exists?(partial_name,nil,true)
+        render partial: partial_name, locals: {product_customization_type: product_customization_type, param_prefix: param_prefix}
+      elsif lookup.exists?(partial_name2,nil,true)
+        render partial: partial_name2, locals: {product_customization_type: product_customization_type, param_prefix: param_prefix}
+      else
+        render partial: "spree/products/customizations/custom_partial_not_found", locals: {product_customization_type: product_customization_type, param_prefix: param_prefix}
+      end
+    end
+
     private
 
     def validation_attributes(option)

--- a/app/views/spree/products/_customizations.html.erb
+++ b/app/views/spree/products/_customizations.html.erb
@@ -1,6 +1,4 @@
 <% if !!@product.product_customization_types && @product.product_customization_types.present? %>
-  <%# for finding optional partials %>
-  <% lookup = ActionView::LookupContext.new(ActionController::Base.view_paths, {formats: [:html]}) %>
 
   <div id="product-customizations">
     <div class= 'col-sm-12'>
@@ -8,39 +6,17 @@
     </div>
     <ul class="list-group list-unstyled">
       <% @product.product_customization_types.group_by{ |x| calculator_name(x) }.each do |product_customization_grouped_by_calc_type| %>
-        <% product_clac_name, product_customization_type_group = product_customization_grouped_by_calc_type %>
+        <% product_calc_name, product_customization_type_group = product_customization_grouped_by_calc_type %>
         <div class='col-sm-12'>
           <legend><%= product_customization_type_group.first.presentation %></legend>
         </div>
         <% product_customization_type_group.each do |product_customization_type| %>
-          <%# render a custom partial based on the customization name? %>
-          <% param_prefix = "product_customizations[#{product_customization_type.id}]" %>
-          <% partial_name = "spree/products/customizations/customization_type/#{product_customization_type.name}" %>
-          <% if lookup.exists?(partial_name,nil,true) %>
-            <%= render partial: partial_name, locals: {product_customization_type: product_customization_type, param_prefix: param_prefix} %>
-          <% else %>
-            <% partial_name = "spree/products/customizations/calculator_type/#{product_clac_name}" %>
-            <% if lookup.exists?(partial_name,nil,true) %>
-              <%= render partial: partial_name, locals: {product_customization_type: product_customization_type, param_prefix: param_prefix} %>
-            <% else %>
-              <li>
-                <div class="col-md-<%= Spree.t(:variant_col_size) %> form-group">
-                  <p><%= product_customization_type.description  %></p>
-                  <% product_customization_type.customizable_product_options.each_with_index do |customizable_product_option, index| %>
-                    <h5 class="presentation-for-customizable-product-option">
-                      <%= customizable_product_option.presentation %>
-                    </h5>
-                    <div class="form-for-customizable-product-option <%= "customization_option_#{index}" %>">
-                      <%= text_field_tag "#{param_prefix}[#{customizable_product_option.id}]","", class: "customization form-control", placeholder:  customizable_product_option.description%>
-                    </div>
-                  <% end # options.each %>
-                </div>
-              </li>
-            <% end %> <%# lookup.exists? %>
-          <% end %> <%# lookup.exists? %>
+          <%# render a partial for product_customization_type (first check in /customization_types, then check /calculator_type, finally fall back to _custom_partial_not_found) %>
+          <%= render_partial_for_customization_type(product_customization_type, product_calc_name) %>
         <% end %> <%# each product_customization_type %>
         <div class='col-sm-12'></div>
       <% end %> <%# each product_customization_grouped_by_calc_type %>
     </ul>
   </div> <!-- product-customizations -->
+
 <% end %>

--- a/app/views/spree/products/_pricing.html.erb
+++ b/app/views/spree/products/_pricing.html.erb
@@ -62,10 +62,11 @@
       return (input - 0) == input && input.length > 0;
     }
 
-    function compute_variant_price_diff(base_price) {
+    function compute_variant_price_diff(base_price, context) {
+      context = context || document;
       var variant_price = 0;
 
-      $("#product-variants input[type='radio']:checked").each (function() {
+      $("#product-variants input[type='radio']:checked", context).each (function() {
         variant_price = variant_price_map[$(this).val()];
       });
 
@@ -77,11 +78,12 @@
 
     }
 
-    function compute_configuration_price() {
+    function compute_configuration_price(context) {
+      context = context || document;
       var configuration_price = 0;
 
       // for selects or checkboxes
-      $("select.ad-hoc-option-select, input:checked.ad-hoc-option-select").each(function() {
+      $("select.ad-hoc-option-select, input:checked.ad-hoc-option-select", context).each(function() {
         // the prompt: 'None' in the select tag yields an empty string, which I can't use in the price calcuation
         var val = $(this).val();
 
@@ -101,11 +103,12 @@
       return configuration_price;
     }
 
-    function compute_customization_price() {
+    function compute_customization_price(context) {
+      context = context || document;
       var price = 0;
 
       // for selects or checkboxes
-      $(".customization_price").each(function() {
+      $(".customization_price", context).each(function() {
         var val = $(this).val();
 
         if (isNumeric(val)) {
@@ -116,7 +119,18 @@
       return price;
     }
 
-    function updatePrice() {
+    function updatePrice(cartFormContext) {
+      // cartFormContext is optional argument to make sure price is only updated in the correct product cart-form
+      if (cartFormContext === undefined){
+        // fallback to old functionality if cartFormContext is not given
+        updatePriceWithoutCartContext();
+      } else {
+        updatePriceWithCartContext(cartFormContext);
+      }
+      
+    }
+
+    function updatePriceWithoutCartContext(){
       var cur_variant_price_diff = compute_variant_price_diff(base_price);
       var cur_configuration_price = compute_configuration_price();
       var cur_customization_price = compute_customization_price();
@@ -124,6 +138,15 @@
 
       var region = $.formatCurrency.getRegionFromCurrency("<%= current_pricing_options.currency %>");
       $('.price.selling').text(cur_price.toFixed(2)).formatCurrency({region: region});
+    }
+
+    function updatePriceWithCartContext(cartFormContext){
+      var cur_variant_price_diff = compute_variant_price_diff(base_price, cartFormContext);
+      var cur_configuration_price = compute_configuration_price(cartFormContext);
+      var cur_customization_price = compute_customization_price(cartFormContext);
+      var cur_price = base_price + cur_variant_price_diff + cur_configuration_price + cur_customization_price;
+      var region = $.formatCurrency.getRegionFromCurrency("<%= current_pricing_options.currency %>");
+      $('.price.selling', cartFormContext).text(cur_price.toFixed(2)).formatCurrency({region: region});
     }
 
     //]]>

--- a/app/views/spree/products/customizations/README.txt
+++ b/app/views/spree/products/customizations/README.txt
@@ -13,5 +13,6 @@ calculator_type/_my_calc.html.erb
 
 The partials are selected in this order is
 
-1) customization_type
-2) calculator_type
+1) /customization_type/_my_calc.html.erb
+2) /calculator_type/_my_calc.html.erb
+3) _custom_partial_not_found.html.erb

--- a/app/views/spree/products/customizations/_custom_partial_not_found.html.erb
+++ b/app/views/spree/products/customizations/_custom_partial_not_found.html.erb
@@ -1,0 +1,13 @@
+<li>
+  <div class="col-md-<%= Spree.t(:variant_col_size) %> form-group">
+    <p><%= product_customization_type.description  %></p>
+    <% product_customization_type.customizable_product_options.each_with_index do |customizable_product_option, index| %>
+      <h5 class="presentation-for-customizable-product-option">
+        <%= customizable_product_option.presentation %>
+      </h5>
+      <div class="form-for-customizable-product-option <%= "customization_option_#{index}" %>">
+        <%= text_field_tag "#{param_prefix}[#{customizable_product_option.id}]","", class: "customization form-control", placeholder:  customizable_product_option.description%>
+      </div>
+    <% end # options.each %>
+  </div>
+</li>

--- a/app/views/spree/products/customizations/calculator_type/_amount_times_constant.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_amount_times_constant.html.erb
@@ -1,20 +1,28 @@
 <%# render the (possibly shared) calculator %>
+<%# set id of the input field for the calculator. %>
 <% cust_dom_id = "amount_times_constant_input_#{product_customization_type.customizable_product_options.first.id}" %>
+<%# render a partial that includes the javascript required to perform the price calculation. This JS is added to the bottom of the body tag according to /overrides/add_flexi_variants_javascript_body_yield.rb %>
 <%= render partial: "spree/products/customizations/calculator/#{calculator_name(product_customization_type)}", locals: {calculator: product_customization_type.calculator} %>
-<%# add the 'change' listener for this particular file input, which will make use of the calculator above %>
 
+
+<%# add the 'change' listener for this particular file input, which will make use of the calculator above %>
+<%# This JS, like the calculation function above, goes in content_for :flexi_variants_body_js %>
 <%= content_for :flexi_variants_body_js do %>
   <%= javascript_tag do %>
     $(document).on('keyup', '#<%= cust_dom_id %>', function(e) {
 
+      
       var text_field = $(this);
+      // find cart form that we are operating on so we can pass it to the updatePrice function
+      var cartForm = $(text_field).closest("#cart-form");
 
       delay(function(){
 
         // update the hidden price field for this file input
         $(text_field).siblings(".customization_price").val(calculate_amount_times_constant_price(text_field));
 
-        updatePrice();
+        // pass an cart form object to updatePrice to make sure we scope only this object
+        updatePrice(cartForm);
       }, 1000 ); // delay
     }); // keyup
   <% end %>

--- a/app/views/spree/products/customizations/calculator_type/_customization_image.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_customization_image.html.erb
@@ -7,10 +7,12 @@
   <%= javascript_tag do %>
     $(document).on('change', '#<%= cust_dom_id %>', function(e) {
 
+      // find cart form that we are operating on so we can pass it to the updatePrice function
+      var cartForm = $(this).closest("#cart-form");
       // update the hidden price field for this file input
       $(this).siblings(".customization_price").val(calculate_customization_image_price(this));
 
-      updatePrice();
+      updatePrice(cartForm);
 
     }); // change()
   <% end %>

--- a/app/views/spree/products/customizations/calculator_type/_engraving.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_engraving.html.erb
@@ -12,13 +12,15 @@
       $(document).on('keyup', '#<%= cust_dom_id %>', function(e) {
 
         var text_field = $(this);
+        // find cart form that we are operating on so we can pass it to the updatePrice function
+        var cartForm = $(text_field).closest("#cart-form");
 
         delay(function(){
 
           // update the hidden price field for this file input
           $(text_field).siblings(".customization_price").val(calculate_engraving_price(text_field));
 
-          updatePrice();
+          updatePrice(cartForm);
         }, 1000 ); // delay
       }); // keyup
     <% end %>

--- a/app/views/spree/products/customizations/calculator_type/_product_area.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_product_area.html.erb
@@ -8,12 +8,14 @@
   <%= javascript_tag do %>
     function product_area_keyup() {
       var text_field = $(this);
+      // find cart form that we are operating on so we can pass it to the updatePrice function
+      var cartForm = $(text_field).closest("#cart-form");
 
       delay(function(){
 
         // update the hidden price field for this file input
         $(text_field).parent().parent().find(".customization_price").val(calculate_product_area_price(text_field));
-        updatePrice();
+        updatePrice(cartForm);
       }, 1000 ); // delay
     }; // keyup
 

--- a/spec/factories/calculators_factory.rb
+++ b/spec/factories/calculators_factory.rb
@@ -1,4 +1,16 @@
 FactoryBot.define do
   factory :no_charge_calculator, class: Spree::Calculator::NoCharge do
   end
+  factory :customization_image_calculator, class: Spree::Calculator::CustomizationImage do
+  end
+  factory :product_area_calculator, class: Spree::Calculator::ProductArea do
+    preferred_multiplier 5
+    preferred_min_pricing_area 1
+  end
+  factory :amount_times_constant_calculator, class: Spree::Calculator::AmountTimesConstant do
+    preferred_multiplier 10
+  end
+  factory :engraving_calculator, class: Spree::Calculator::Engraving do
+    preferred_price_per_letter 0.03
+  end
 end

--- a/spec/factories/product_customizations_factory.rb
+++ b/spec/factories/product_customizations_factory.rb
@@ -52,5 +52,22 @@ FactoryBot.define do
     sequence(:presentation) { |n| "Product Customization Type Presentation ##{n} - #{Kernel.rand(9999)}" }
 
     calculator { |p| p.association(:no_charge_calculator) }
+
+    trait :customization_image do
+      calculator { |p| p.association(:customization_image_calculator) }
+    end
+
+    trait :product_area do
+      calculator { |p| p.association(:product_area_calculator) }
+    end
+
+    trait :amount_times_constant do
+      calculator { |p| p.association(:amount_times_constant_calculator) }
+    end
+
+    trait :engraving do
+      calculator { |p| p.association(:engraving_calculator) }
+    end
+
   end
 end

--- a/spec/features/product_page_customizations_feature_spec.rb
+++ b/spec/features/product_page_customizations_feature_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe 'Customizations', :js, type: :feature do
+  include IntegrationHelpers
+
+  let(:test_product) { create(:product, name: 'Test Product', price: 12.99) }
+  let(:test_product2) { create(:product, name: 'Another Test Product', price: 99.99) }
+
+  context 'With more than one customizable product on a page' do
+    it 'will only apply customizations to the correct product price' do
+      amount = 3
+      prod_cust_type, cpos = setup_product_customization_type_and_options(test_product, "amount_times_constant")
+      prod_cust_type2, cpos2 = setup_product_customization_type_and_options(test_product2, "amount_times_constant")
+      visit spree.product_path(test_product)
+      # add a fake price to a page to verify that it doesn't change when product is customized
+      page.execute_script("$('body').append('<div class=\"price selling\">$1000</div>')");
+      fill_in "amount_times_constant_input_#{cpos.first.id}", with: 3
+      # set calculator factory to multiplier of 10
+      expected_amount = amount * 10 + test_product.price
+      expect(page).to have_content("$#{expected_amount}")
+      # other fake price should not be changed
+      expect(page).to have_content("$1000")
+    end
+  end
+
+  context 'Cutomization types render correctly on product page' do
+
+    it 'will add a text field as customization field by default' do
+      prod_cust_type, cpos = setup_product_customization_type_and_options(test_product, "no_charge")
+      visit spree.product_path(test_product)
+      expect(page).to have_css("input[type='text']#product_customizations_#{prod_cust_type.id}_#{cpos.first.id}")
+      fill_in "product_customizations_#{prod_cust_type.id}_#{cpos.first.id}", with: "This is a comment"
+      # give a little time to make sure the price doesn't change
+      sleep(2)
+      expect(page).to have_content("$#{test_product.price}")
+    end
+
+    it 'will add a file upload if customization image calculator is used' do
+      prod_cust_type, cpos = setup_product_customization_type_and_options(test_product, "customization_image")
+      visit spree.product_path(test_product)
+      expect(page).to have_css("input[type='file']#customization_image_#{prod_cust_type.id}")
+    end
+
+    it 'will add length and width fields if product area calculator is used' do
+      length = 3
+      width = 4
+      prod_cust_type, cpos = setup_product_customization_type_and_options(test_product, "product_area")
+      visit spree.product_path(test_product)
+      expect(page).to have_css("input[type='text']#product_area_input_#{cpos.first.id}")
+      expect(page).to have_css("input[type='text']#product_area_input_#{cpos.last.id}")
+      fill_in "product_area_input_#{cpos.first.id}", with: length.to_s
+      fill_in "product_area_input_#{cpos.last.id}", with: width.to_s
+      # set calculator factory to multiplier of 5
+      expected_amount = length * width * 5 + test_product.price
+      expect(page).to have_content("$#{expected_amount}")
+    end
+
+    it 'will add amount field if amount times constant calculator is used' do
+      amount = 3
+      prod_cust_type, cpos = setup_product_customization_type_and_options(test_product, "amount_times_constant")
+      visit spree.product_path(test_product)
+      expect(page).to have_css("input[type='text']#amount_times_constant_input_#{cpos.first.id}")
+      fill_in "amount_times_constant_input_#{cpos.first.id}", with: 3
+      # set calculator factory to multiplier of 10
+      expected_amount = amount * 10 + test_product.price
+      expect(page).to have_content("$#{expected_amount}")
+    end
+
+    it 'will add text field if engraving calculator is used' do
+      engraving_word = "This is my engraving"
+      prod_cust_type, cpos = setup_product_customization_type_and_options(test_product, "engraving")
+      visit spree.product_path(test_product)
+      expect(page).to have_css("input[type='text']#engraving_input_#{cpos.first.id}")
+      fill_in "engraving_input_#{cpos.first.id}", with: engraving_word
+      # set calculator factory to multiplier of .03 per letter
+      expected_amount = engraving_word.length * 0.03 + test_product.price
+      expect(page).to have_content("$#{expected_amount}")
+    end
+
+
+  end
+end

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -56,6 +56,33 @@ module IntegrationHelpers
     end
   end
 
+  def setup_product_customization_type_and_options(product, calculator_name)
+    cpos = []
+    case calculator_name
+    when "amount_times_constant"
+      prod_cust_type = create(:product_customization_type, :amount_times_constant)
+      cpos << create(:customizable_product_option, product_customization_type: prod_cust_type)
+    when "customization_image"
+      prod_cust_type = create(:product_customization_type, :customization_image)
+      cpos << create(:customizable_product_option, product_customization_type: prod_cust_type)
+    when "engraving"
+      prod_cust_type = create(:product_customization_type, :engraving)
+      cpos << create(:customizable_product_option, product_customization_type: prod_cust_type)
+    when "product_area"
+      prod_cust_type = create(:product_customization_type, :product_area)
+      cpos << create(:customizable_product_option, product_customization_type: prod_cust_type)
+      cpos << create(:customizable_product_option, product_customization_type: prod_cust_type)
+    when "no_charge"
+      prod_cust_type = create(:product_customization_type)
+      cpos << create(:customizable_product_option, product_customization_type: prod_cust_type)
+    else
+      raise "unknown calculator_name"
+    end
+
+    product.product_customization_types << prod_cust_type
+    return prod_cust_type, cpos
+  end
+
   def setup_option_types_plus_ad_hoc_option_type_size(product)
     size_option_type = create(:option_type, name: 'size', presentation: 'Size')
     size_ad_hoc_option_type = create(:ad_hoc_option_type, option_type_id: size_option_type.id, product_id: product.id, position: 1)


### PR DESCRIPTION
…ePrice function.

Although Solidus isn't set up out-of-the-box to allow multiple cart-forms on the same page, it is still good practice to make sure that the updatePrice function only interacts with the form fields on the correct product.

I added an optional context argument to the updatePrice function so that it will only update the price inside the context it is given (i.e. for the correct #cart-form).

I also added a test to illustrate the above context problem and several tests to exercise the calculators from the front end users perspective.

I also moved the partial lookup logic (first look in customization_type, then calculator_type, then fallback to a default) to a helper to clean up the view layer a bit.